### PR TITLE
30.01.16-31.01.16 changelist

### DIFF
--- a/src/services/database.coffee
+++ b/src/services/database.coffee
@@ -18,25 +18,11 @@ module.exports =
   initialize: (cb) ->
     Pool.getConnection (err) -> cb err
 
-  # Execute sql
-  exec: (sql=null) -> new Promise((resolve, reject) ->
+  exec: (sql, values) -> new Promise((resolve, reject) ->
     Pool.getConnection (err, connection) ->
       reject(err) if err
 
-      # Execute query
-      if sql is null
-        resolve()
-      else
-        connection.query(sql, (err, rows) -> resolve(rows))
-
-      # Release connection
-      connection.release()
-  )
-
-  execp: (sql, values) -> new Promise((resolve, reject) ->
-    Pool.getConnection (err, connection) ->
-      reject(err) if err
-
+      values = values || []
 
       connection.query(sql, values, (err, rows) ->
         connection.release()

--- a/src/services/database.coffee
+++ b/src/services/database.coffee
@@ -32,3 +32,15 @@ module.exports =
       # Release connection
       connection.release()
   )
+
+  execp: (sql, values) -> new Promise((resolve, reject) ->
+    Pool.getConnection (err, connection) ->
+      reject(err) if err
+
+
+      connection.query(sql, values, (err, rows) ->
+        connection.release()
+        reject(err) if err
+        resolve(rows)
+      )
+  )

--- a/src/services/handler.coffee
+++ b/src/services/handler.coffee
@@ -67,12 +67,15 @@ class Handler
           delete global.Server.clients[@id]
 
           # Close opened connection
-          if global.Server.clients[@user.id]
-            global.Server.clients[@user.id].send '<dup />'
-            global.Server.clients[@user.id].socket.end()
+          dupUser = global.Server.rooms[@user.chat]?[@user.id]
+
+          if dupUser
+            dupUser.send '<dup />'
+            dupUser.socket.end()
 
           @id = @user.id
           global.Server.clients[@user.id] = @
+
 
           Chat.joinRoom.call(@)
         ).catch((err) => @logger.log @logger.level.ERROR, err, null)
@@ -172,14 +175,14 @@ class Handler
     @logger.log @logger.level.DEBUG, "-> Sent: #{packet}"
 
   broadcast: (packet) ->
-    console.log global.Server.rooms
 
-    for client in global.Server.rooms[@user.chat]
-      continue if @user.id == client
+    for _, client of global.Server.rooms[@user.chat]
+      continue if @user.id == client.user.id
 
-      console.log "Broadcasting from #{@user.id} to #{client}"
+      console.log "Broadcasting from #{@user.id} to #{client.id}"
 
-      global.Server.getClientById(client).send packet
+      client.send packet
+
 
     # Debug
     @logger.log @logger.level.DEBUG, "-> Broadcasted: #{packet}"

--- a/src/services/handler.coffee
+++ b/src/services/handler.coffee
@@ -151,9 +151,9 @@ class Handler
 
         msg = builder.create(packetTag).append('E', "#{Date.now()}").append('u', fromID).append('t', message)
         if s & 2
-            msg.append('s', s)
+          msg.append('s', s)
         if packetTag == 'z' or s & 2
-            msg.append('d', if packetTag == 'z' then toID else fromID)
+          msg.append('d', if packetTag == 'z' then toID else fromID)
 
         global.Server.getClientById(toID)?.send(msg.compose())
       when packetTag.indexOf('w') is 0

--- a/src/services/server.coffee
+++ b/src/services/server.coffee
@@ -47,16 +47,16 @@ class Server
       socket.on 'end', =>
         @logger.log @logger.level.DEBUG, "A user has been disconnected!"
 
-        if @rooms[client.user.chat]
-          clientIndex = @rooms[client.user.chat].indexOf(client.id)
+        if @clients[client.id] == client
+          if @rooms[client.user.chat]
+            clientIndex = @rooms[client.user.chat].indexOf(client.id)
 
-          client.broadcast(builder.create('l').append('u', client.user.id).compose())
+            client.broadcast(builder.create('l').append('u', client.user.id).compose())
 
-          @rooms[client.user.chat].splice(clientIndex, 1) if clientIndex > -1
+            @rooms[client.user.chat].splice(clientIndex, 1) if clientIndex > -1
 
-          #delete @rooms[client.user.chat] if @rooms[client.user.chat].length < 1
-
-        delete @clients[client.id]
+            #delete @rooms[client.user.chat] if @rooms[client.user.chat].length < 1
+          delete @clients[client.id]
 
       socket.on 'error', (err) =>
         @logger.log @logger.level.ERROR, "Socket exception from #{socket.remoteAddress}", err

--- a/src/services/server.coffee
+++ b/src/services/server.coffee
@@ -49,11 +49,10 @@ class Server
 
         if @clients[client.id] == client
           if @rooms[client.user.chat]
-            clientIndex = @rooms[client.user.chat].indexOf(client.id)
 
             client.broadcast(builder.create('l').append('u', client.user.id).compose())
 
-            @rooms[client.user.chat].splice(clientIndex, 1) if clientIndex > -1
+            delete @rooms[client.user.chat][client.user.id]
 
             #delete @rooms[client.user.chat] if @rooms[client.user.chat].length < 1
           delete @clients[client.id]

--- a/src/services/server.coffee
+++ b/src/services/server.coffee
@@ -50,7 +50,8 @@ class Server
         if @clients[client.id] == client
           if @rooms[client.user.chat]
 
-            client.broadcast(builder.create('l').append('u', client.user.id).compose())
+            if client.user.authenticated
+              client.broadcast(builder.create('l').append('u', client.user.id).compose())
 
             delete @rooms[client.user.chat][client.user.id]
 

--- a/src/workers/chat.coffee
+++ b/src/workers/chat.coffee
@@ -9,7 +9,7 @@ module.exports =
   joinRoom: ->
     return if @user.chat < 1 or isNaN(@user.chat) is true
 
-    database.exec("SELECT * FROM chats WHERE id = '#{@user.chat}' LIMIT 1 ").then((data) =>
+    database.execp('SELECT * FROM chats WHERE id = ? LIMIT 1', [@user.id]).then((data) =>
       if @user.chat is 8
         @send '<i b=";=;=;=- Cant ;=" f="932" v="1" cb="0"  />'
         @send '<w v="0 0 1"  />'
@@ -93,7 +93,7 @@ module.exports =
       @send builder.create('m').append('t', "/s#{@chat.sc}").append('d', '1010208').compose()
 
       ## Room messages
-      database.exec("SELECT * FROM (SELECT * FROM messages WHERE id='#{@user.chat}' AND pool='#{@chat.onPool}' ORDER BY time DESC LIMIT 15) sub ORDER BY time ASC LIMIT 0,15").then((data) =>
+      database.execp('SELECT * FROM (SELECT * FROM messages WHERE id = ? AND pool = ? ORDER BY time DESC LIMIT 15) sub ORDER BY time ASC LIMIT 0,15', [ @user.chat, @chat.onPool ]).then((data) =>
         data.forEach((message) => @send "<m t=\"#{message.message}\" u=\"#{message.uid}\"  />")
 
         ## Done packet
@@ -104,6 +104,6 @@ module.exports =
   sendMessage: (user, message) ->
     @broadcast(builder.create('m').append('t', message).append('u', user).compose())
 
-    database.exec("INSERT INTO messages (id, uid, message, name, registered, avatar, time, pool) values ('#{@user.chat}', '#{@user.id}', '#{message}', '#{@user.nickname}', '#{@user.username||'unregistered'}', '#{@user.avatar}', '#{math.time()}', '#{@chat.onPool}')").then((data) ->
+    database.execp('INSERT INTO messages (id, uid, message, name, registered, avatar, time, pool) values (?, ?, ?, ?, ?, ?, ?, ?)', [ @user.chat, @user.id, message, @user.nickname, @user.username||'unregistered', @user.avatar, math.time(), @chat.onPool ]).then((data) ->
       logger.log logger.level.DEBUG, 'New message sent'
     ).catch((err) -> logger.log logger.level.ERROR, 'Failed to send a message to the database', err)

--- a/src/workers/chat.coffee
+++ b/src/workers/chat.coffee
@@ -22,9 +22,10 @@ module.exports =
 
       ## Push the user to the rooms object
       if typeof global.Server.rooms[@user.chat] is 'object'
-        global.Server.rooms[@user.chat].push @user.id
+        global.Server.rooms[@user.chat][@user.id] = @
       else
-        global.Server.rooms[@user.chat] = new Array @user.id
+        global.Server.rooms[@user.chat] = { }
+        global.Server.rooms[@user.chat][@user.id] = @
 
       @chat.attached = try JSON.parse(@chat.attached) catch error then {}
       @chat.onPool = @chat.onPool || 0
@@ -58,12 +59,10 @@ module.exports =
       @send builder.create('w').append('v', "#{@chat.onPool} #{@chat.pool}").compose()
 
       ## Send connected users to client
-      for userId in global.Server.rooms[@user.chat]
-        if userId is @user.id or !global.Server.clients[userId] or global.Server.clients[userId].chat.onPool != @chat.onPool
-          break
+      for _, user of global.Server.rooms[@user.chat]
+        if user.id is @user.id or !global.Server.clients[user.id] or user.chat.onPool != @chat.onPool
+          continue
 
-        user = global.Server.clients[userId].user
-        
         packet = builder.create('u')
         packet.append('cb', '1414865425')
         packet.append('s', '1')

--- a/src/workers/chat.coffee
+++ b/src/workers/chat.coffee
@@ -59,9 +59,11 @@ module.exports =
       @send builder.create('w').append('v', "#{@chat.onPool} #{@chat.pool}").compose()
 
       ## Send connected users to client
-      for _, user of global.Server.rooms[@user.chat]
-        if user.id is @user.id or !global.Server.clients[user.id] or user.chat.onPool != @chat.onPool
+      for _, client of global.Server.rooms[@user.chat]
+        if client.id is @user.id or !global.Server.clients[client.id] or client.chat.onPool != @chat.onPool
           continue
+
+        user = client.user
 
         packet = builder.create('u')
         packet.append('cb', '1414865425')

--- a/src/workers/chat.coffee
+++ b/src/workers/chat.coffee
@@ -9,7 +9,7 @@ module.exports =
   joinRoom: ->
     return if @user.chat < 1 or isNaN(@user.chat) is true
 
-    database.execp('SELECT * FROM chats WHERE id = ? LIMIT 1', [@user.chat]).then((data) =>
+    database.exec('SELECT * FROM chats WHERE id = ? LIMIT 1', [@user.chat]).then((data) =>
       if @user.chat is 8
         @send '<i b=";=;=;=- Cant ;=" f="932" v="1" cb="0"  />'
         @send '<w v="0 0 1"  />'
@@ -93,7 +93,7 @@ module.exports =
       @send builder.create('m').append('t', "/s#{@chat.sc}").append('d', '1010208').compose()
 
       ## Room messages
-      database.execp('SELECT * FROM (SELECT * FROM messages WHERE id = ? AND pool = ? ORDER BY time DESC LIMIT 15) sub ORDER BY time ASC LIMIT 0,15', [ @user.chat, @chat.onPool ]).then((data) =>
+      database.exec('SELECT * FROM (SELECT * FROM messages WHERE id = ? AND pool = ? ORDER BY time DESC LIMIT 15) sub ORDER BY time ASC LIMIT 0,15', [ @user.chat, @chat.onPool ]).then((data) =>
         data.forEach((message) => @send "<m t=\"#{message.message}\" u=\"#{message.uid}\"  />")
 
         ## Done packet
@@ -104,6 +104,6 @@ module.exports =
   sendMessage: (user, message) ->
     @broadcast(builder.create('m').append('t', message).append('u', user).compose())
 
-    database.execp('INSERT INTO messages (id, uid, message, name, registered, avatar, time, pool) values (?, ?, ?, ?, ?, ?, ?, ?)', [ @user.chat, @user.id, message, @user.nickname, @user.username||'unregistered', @user.avatar, math.time(), @chat.onPool ]).then((data) ->
+    database.exec('INSERT INTO messages (id, uid, message, name, registered, avatar, time, pool) values (?, ?, ?, ?, ?, ?, ?, ?)', [ @user.chat, @user.id, message, @user.nickname, @user.username||'unregistered', @user.avatar, math.time(), @chat.onPool ]).then((data) ->
       logger.log logger.level.DEBUG, 'New message sent'
     ).catch((err) -> logger.log logger.level.ERROR, 'Failed to send a message to the database', err)

--- a/src/workers/chat.coffee
+++ b/src/workers/chat.coffee
@@ -9,7 +9,7 @@ module.exports =
   joinRoom: ->
     return if @user.chat < 1 or isNaN(@user.chat) is true
 
-    database.execp('SELECT * FROM chats WHERE id = ? LIMIT 1', [@user.id]).then((data) =>
+    database.execp('SELECT * FROM chats WHERE id = ? LIMIT 1', [@user.chat]).then((data) =>
       if @user.chat is 8
         @send '<i b=";=;=;=- Cant ;=" f="932" v="1" cb="0"  />'
         @send '<w v="0 0 1"  />'

--- a/src/workers/profile.coffee
+++ b/src/workers/profile.coffee
@@ -3,7 +3,7 @@ database = require "../services/database"
 module.exports =
   getById: (userProfileId) -> new Promise((resolve, reject) ->
     # TODO: Select only the needed data
-    database.execp('SELECT * FROM users WHERE id = ? LIMIT 1', [userProfileId]).then((data) ->
+    database.exec('SELECT * FROM users WHERE id = ? LIMIT 1', [userProfileId]).then((data) ->
       resolve(data[0])
     ).catch((err) -> reject(err))
   )

--- a/src/workers/profile.coffee
+++ b/src/workers/profile.coffee
@@ -3,7 +3,7 @@ database = require "../services/database"
 module.exports =
   getById: (userProfileId) -> new Promise((resolve, reject) ->
     # TODO: Select only the needed data
-    database.exec("SELECT * FROM users WHERE id = '#{userProfileId}' LIMIT 1 ").then((data) ->
+    database.execp('SELECT * FROM users WHERE id = ? LIMIT 1', [userProfileId]).then((data) ->
       resolve(data[0])
     ).catch((err) -> reject(err))
   )

--- a/src/workers/user.coffee
+++ b/src/workers/user.coffee
@@ -35,7 +35,7 @@ module.exports =
 
       @send v.compose()
       @send builder.create('c').append('t', '/bd').compose()
-      @send builder.create('c').append('t', '/b #{user.id},5,,#{user.nickname},#{user.avatar},#{user.url},0,0,0,0,0,0,0,0,0,0,0,0,0,0').compose()
+      @send builder.create('c').append('t', "/b #{user.id},5,,#{user.nickname},#{user.avatar},#{user.url},0,0,0,0,0,0,0,0,0,0,0,0,0,0").compose()
       @send builder.create('c').append('t', 'bf').compose()
       @send builder.create('ldone').compose()
     )

--- a/src/workers/user.coffee
+++ b/src/workers/user.coffee
@@ -71,6 +71,7 @@ module.exports =
     @resetDetails(@user.id, (res) =>
       if !res
         @handler.send builder.create('logout').append('e', 'F036').compose()
+        @handler.dispose()
         callback(false, "Reset details failed for user with id #{@user.id}")
         return
 

--- a/src/workers/user.coffee
+++ b/src/workers/user.coffee
@@ -11,7 +11,7 @@ module.exports =
     #   Complete all the attrs with real data.
     # INFO:
     #   d2 - married id
-    database.exec("SELECT * FROM users WHERE username = '#{name}' AND loginKey = '#{pw}' LIMIT 1 ").then((data) =>
+    database.execp('SELECT * FROM users WHERE username = ? AND loginKey = ? LIMIT 1', [name, pw]).then((data) =>
       return if data.length < 1
 
       user = data[0]
@@ -90,7 +90,7 @@ module.exports =
     )
 
   resetDetails: (userId, callback) ->
-    database.exec("SELECT * FROM users WHERE id = '#{userId}' AND k = '#{@user.k}' AND k3 = '#{@user.k3}' LIMIT 1 ").then((data) =>
+    database.execp('SELECT * FROM users WHERE id = ? AND k = ? AND k3 = ? LIMIT 1', [userId, @user.k, @user.k3]).then((data) =>
       if data.length < 1
         callback(false)
       else if data[0].username is 'unregistered'
@@ -118,7 +118,7 @@ module.exports =
 
   updateDetails: (callback) ->
     if @user.id != 0
-      database.exec("UPDATE users SET nickname = '#{@user.nickname}', avatar = '#{@user.avatar}', url = '#{@user.url}', remoteAddress = '#{@handler.socket.remoteAddress}' WHERE id = '#{@user.id}'").then((data) =>
+      database.execp('UPDATE users SET nickname = ?, avatar = ?, url = ?, remoteAddress = ? WHERE id = ?', [@user.nickname, @user.avatar, @user.url, @handler.socket.remoteAddress, @user.id]).then((data) =>
         @user.authenticated = true
 
         callback(true, null)

--- a/src/workers/user.coffee
+++ b/src/workers/user.coffee
@@ -11,7 +11,7 @@ module.exports =
     #   Complete all the attrs with real data.
     # INFO:
     #   d2 - married id
-    database.execp('SELECT * FROM users WHERE username = ? AND loginKey = ? LIMIT 1', [name, pw]).then((data) =>
+    database.exec('SELECT * FROM users WHERE username = ? AND loginKey = ? LIMIT 1', [name, pw]).then((data) =>
       return if data.length < 1
 
       user = data[0]
@@ -91,7 +91,7 @@ module.exports =
     )
 
   resetDetails: (userId, callback) ->
-    database.execp('SELECT * FROM users WHERE id = ? AND k = ? AND k3 = ? LIMIT 1', [userId, @user.k, @user.k3]).then((data) =>
+    database.exec('SELECT * FROM users WHERE id = ? AND k = ? AND k3 = ? LIMIT 1', [userId, @user.k, @user.k3]).then((data) =>
       if data.length < 1
         callback(false)
       else if data[0].username is 'unregistered'
@@ -119,7 +119,7 @@ module.exports =
 
   updateDetails: (callback) ->
     if @user.id != 0
-      database.execp('UPDATE users SET nickname = ?, avatar = ?, url = ?, remoteAddress = ? WHERE id = ?', [@user.nickname, @user.avatar, @user.url, @handler.socket.remoteAddress, @user.id]).then((data) =>
+      database.exec('UPDATE users SET nickname = ?, avatar = ?, url = ?, remoteAddress = ? WHERE id = ?', [@user.nickname, @user.avatar, @user.url, @handler.socket.remoteAddress, @user.id]).then((data) =>
         @user.authenticated = true
 
         callback(true, null)

--- a/src/workers/user.coffee
+++ b/src/workers/user.coffee
@@ -2,6 +2,7 @@ logger = new (require "../utils/logger")(name: 'User')
 parser = require "../utils/parser"
 math = require "../utils/math"
 database = require "../services/database"
+builder = require "../utils/builder"
 
 module.exports =
   login: (name, pw) ->
@@ -14,16 +15,29 @@ module.exports =
       return if data.length < 1
 
       user = data[0]
-      days = if parseInt(user.days) > 0 then "d1=\"#{user.days}\"" else ''
-      married = if parseInt(user.d2) > 0 then "d2=\"#{user.d2}\"" else ''
+      v = builder.create('v')
+      v.append('d1', user.days) if parseInt(user.days) > 0
+      v.append('d2', user.d2) if parseInt(user.d2) > 0
 
-      str = 'd4="2209282" d5="6292512" d6="2097193" d9="262144"'
+      v.append('d4', 2209282)
+        .append('d5', '6292512')
+        .append('d6', '2097193')
+        .append('d9', '262144')
+        .append('d0', user.d0)
+        .append('d3', user.d3)
+        .append('dx', user.xats)
+        .append('dt', Date.now())
+        .append('i', user.id)
+        .append('n', user.username)
+        .append('k2', user.k2)
+        .append('k3', user.k3)
+        .append('k1', user.k)
 
-      @send "<v d0=\"#{user.d0}\" #{days} #{married} d3=\"#{user.d3}\" #{str} dx=\"#{user.xats}\" dt=\"#{Date.now()}\" i=\"#{user.id}\" n=\"#{user.username}\" k2=\"#{user.k2}\" k3=\"#{user.k3}\" k1=\"#{user.k}\"  />"
-      @send '<c t="/bd"  />'
-      @send "<c t=\"/b #{user.id},5,,#{user.nickname},#{user.avatar},#{user.url},0,0,0,0,0,0,0,0,0,0,0,0,0,0\"  />"
-      @send '<c t="/bf"  />'
-      @send '<ldone  />'
+      @send v.compose()
+      @send builder.create('c').append('t', '/bd').compose()
+      @send builder.create('c').append('t', '/b #{user.id},5,,#{user.nickname},#{user.avatar},#{user.url},0,0,0,0,0,0,0,0,0,0,0,0,0,0').compose()
+      @send builder.create('c').append('t', 'bf').compose()
+      @send builder.create('ldone').compose()
     )
 
   # TODO: Improve this
@@ -56,7 +70,7 @@ module.exports =
 
     @resetDetails(@user.id, (res) =>
       if !res
-        @handler.send "<logout e=\"F036\" />"
+        @handler.send builder.create('logout').append('e', 'F036').compose()
         callback(false, "Reset details failed for user with id #{@user.id}")
         return
 
@@ -120,6 +134,6 @@ module.exports =
     return true
 
   logout: ->
-    @send '<dup />'
+    @send builder.create('dup').compose()
     @user = {}
     @dispose()


### PR DESCRIPTION
Time to discuss.
## Changes:
## 1. Private message handling.

The difference between my and your version that my version dispatch both 'z' and 'p' packets.
It seems that your version contains bug. What if global.Server.getClientById(toID) is undefined? Use 

``` coffee
global.Server.getClientById(toID)? 
```

instead.
Question: are we need to emit 'z' private message packages at all? I think it's ok if we renounce 'z' or 'p' package. 'z' packages is more preferable it's format is more clear. Look at the formats in all cases:
<p u="FROM-USER_ID" t="MESSAGE" [s="2" d="FROM-USER_ID"] /> - user receives
<p u="TO-USER_ID" t="MESSAGE" /> - user sends (pm)
<p u="TO-USER_ID" t="MESSAGE" s="2" d="FROM-USER_ID" > - user sends (pc)
 <z u="FROM-USER_ID" t="MESSAGE" [s="2"] d="TO-USER_ID" /> - user receives and sends
## 2. Multichat

Now user can log in several chats. I suggest new Server scheme
![img](http://i.imgur.com/8p7Qd1j.png)
It's clear about rooms, what do clients array means now? Clients array points to id's handlers, which are latest active. For example:
my id is 1337 and i'm connected to chats 15 and 700
i've posted a message in 15. So, my last active chat is 15 and clients[1337] should points to handler with chat == 15
and then i've tickled user at chat 700. Now my latest active chat is 700 and clients[1337] should points to handler with chat == 700
I'm going to implement private message routing soon.
## 3. Prepared statements.

In current realisation, sql injections are possible (and it's easy to perform them)
For example: use userno = "123' OR '1'>'2" to log in as user with id 123
Prepared statements helps to avoid this situation. That's it!
## 4. Dup fix?

We can use my or your version, i think it doesn't matter.
